### PR TITLE
Add boot, floopy, keyboard flags.

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -175,6 +175,12 @@ else
 fi
 echo "parameter: ${FLAGS_REMOTE_ACCESS}"
 
+if [ -n "$BOOT" ]; then
+  echo "[boot]"
+  FLAGS_BOOT="-boot ${BOOT}"
+  echo "parameter: ${FLAGS_BOOT}"
+fi
+
 set -x
 exec /usr/bin/kvm ${FLAGS_REMOTE_ACCESS} \
   -k en-us -m ${RAM} -smp ${SMP} -cpu ${FLAGS_CPU} -usb -usbdevice tablet -no-shutdown \
@@ -182,4 +188,5 @@ exec /usr/bin/kvm ${FLAGS_REMOTE_ACCESS} \
   ${FLAGS_DISK_IMAGE} \
   ${FLAGS_ISO} \
   ${FLAGS_ISO2} \
-  ${FLAGS_NETWORK}
+  ${FLAGS_NETWORK} \
+  ${FLAGS_BOOT}

--- a/startup.sh
+++ b/startup.sh
@@ -187,6 +187,12 @@ if [ -n "$BOOT" ]; then
   echo "parameter: ${FLAGS_BOOT}"
 fi
 
+if [ -n "$KEYBOARD" ]; then
+  echo "[keyboard]"
+  FLAGS_KEYBOARD="-k ${KEYBOARD}"
+  echo "parameter: ${FLAGS_KEYBOARD}"
+fi
+
 set -x
 exec /usr/bin/kvm ${FLAGS_REMOTE_ACCESS} \
   -k en-us -m ${RAM} -smp ${SMP} -cpu ${FLAGS_CPU} -usb -usbdevice tablet -no-shutdown \
@@ -196,4 +202,5 @@ exec /usr/bin/kvm ${FLAGS_REMOTE_ACCESS} \
   ${FLAGS_ISO} \
   ${FLAGS_ISO2} \
   ${FLAGS_NETWORK} \
+  ${FLAGS_KEYBOARD} \
   ${FLAGS_BOOT}

--- a/startup.sh
+++ b/startup.sh
@@ -80,6 +80,12 @@ else
 fi
 echo "parameter: ${FLAGS_DISK_IMAGE}"
 
+if [ -n "$FLOPPY" ]; then
+  echo "[floppy image]"
+  FLAGS_FLOPPY_IMAGE="-fda ${FLOPPY}"
+  echo "parameter: ${FLAGS_FLOPPY_IMAGE}"
+fi
+
 echo "[network]"
 if [ "$NETWORK" == "bridge" ]; then
   NETWORK_BRIDGE="${NETWORK_BRIDGE:-docker0}"
@@ -186,6 +192,7 @@ exec /usr/bin/kvm ${FLAGS_REMOTE_ACCESS} \
   -k en-us -m ${RAM} -smp ${SMP} -cpu ${FLAGS_CPU} -usb -usbdevice tablet -no-shutdown \
   -name ${HOSTNAME} \
   ${FLAGS_DISK_IMAGE} \
+  ${FLAGS_FLOPPY_IMAGE} \
   ${FLAGS_ISO} \
   ${FLAGS_ISO2} \
   ${FLAGS_NETWORK} \


### PR DESCRIPTION
I want to install Windows XP with virtio driver floppy image.

```
-e FLOPPY=/data/virtio-win-1.1.16.vfd \
-e BOOT=once=d \
-e KEYBOARD=ja \
-e DISK_DEVICE=ide \
```

![_2017-03-21_15-56-47](https://cloud.githubusercontent.com/assets/1517645/24135788/0f6f4190-0e4f-11e7-944f-bd2334c44a9f.png)

* [virtio-win-1.1.16.vfd](https://github.com/OpenStackCookbook/OpenStackCookbook/blob/master/virtio-win-1.1.16.vfd)