### PR TITLE
Fix "ISO2 file not found: foo.iso" when setting up ISO2 environment variable

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -57,7 +57,7 @@ if [ -n "$ISO2" ]; then
     if [ ! -f "/data/${basename}" ] || [ "$ISO_DOWNLOAD" != "0" ]; then
       wget -O- "$ISO2" > /data/${basename}
     fi
-    ISO=/data/${basename}
+    ISO2=/data/${basename}
   fi
   FLAGS_ISO2="-drive file=${ISO2},media=cdrom,index=3"
   if [ "${ISO2:0:4}" != "rbd:" ] && [ ! -f "$ISO2" ]; then


### PR DESCRIPTION
Hello maintainer team!

There is a very small logic error (probably from copy/pasting the logic of "ISO" into the "ISO2" block, where the "ISO" environment variable gets overwritten, where it should really be touching "ISO2".
This one char PR fixes that.

Keep up the good work!

Best regards,
Sylvain Huguet